### PR TITLE
feat(sliver): add 2012

### DIFF
--- a/baekjoon/silver/level3/test_2012/JunitTest.java
+++ b/baekjoon/silver/level3/test_2012/JunitTest.java
@@ -1,0 +1,26 @@
+package silver.level3.test_2012;
+
+import org.junit.Test;
+import util.TestUtil;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static util.ThrowingRunnable.runUnchecked;
+
+public class JunitTest {
+    @Test
+    public void test_1() throws IOException {
+        String input = """
+            5
+            1
+            5
+            3
+            1
+            2
+            """;
+        String expectedOutput = "3";
+        String actualOutput = TestUtil.executeTest(input, () -> runUnchecked(() -> Main.main(new String[0])));
+        assertEquals(expectedOutput, actualOutput);
+    }
+}

--- a/baekjoon/silver/level3/test_2012/Main.java
+++ b/baekjoon/silver/level3/test_2012/Main.java
@@ -1,0 +1,31 @@
+package silver.level3.test_2012;
+
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int n = sc.nextInt();
+        int[] arr = new int[n + 1];
+
+        List<Integer> extra = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            int num = sc.nextInt();
+            if (num > n) extra.add(num);
+            else arr[num]++;
+        }
+
+        List<Integer> missing = new ArrayList<>();
+        for (int i = 1; i <= n; i++) {
+            if (arr[i] == 0) missing.add(i);
+            else if (arr[i] > 1) {
+                for (int j = 0; j < arr[i] - 1; j++) extra.add(i);
+            }
+        }
+
+        Collections.sort(extra);
+        long answer = 0;
+        for (int i = 0; i < missing.size(); i++) answer += Math.abs(extra.get(i) - missing.get(i));
+        System.out.print(answer);
+    }
+}


### PR DESCRIPTION
### Summary
- Sort the predicted ranks of N students and calculate the total dissatisfaction as the sum of differences between predicted and actual ranks (1 to N).
- Use long to prevent overflow when summing.

### Changes
- Sort the input array of predicted ranks (O(N log N))
- Assign actual ranks sequentially from 1 to N
- Calculate dissatisfaction as |predicted rank - actual rank|
- Output the total dissatisfaction

### Complexity
- Time: O(N log N) (due to sorting)
- Space: O(N) (array storage)

### Test
- Verified with Baekjoon sample inputs/outputs