### PR TITLE
feat: add 11497

### DIFF
--- a/baekjoon/silver/level1/test_11497/JunitTest.java
+++ b/baekjoon/silver/level1/test_11497/JunitTest.java
@@ -1,0 +1,34 @@
+package silver.level1.test_11497;
+
+import org.junit.Test;
+import util.TestUtil;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static util.ThrowingRunnable.runUnchecked;
+
+public class JunitTest {
+
+    @Test
+    public void test_1() throws IOException {
+        String input = """
+            3
+            7
+            13 10 12 11 10 11 12
+            5
+            2 4 5 7 9
+            8
+            6 6 6 6 6 6 6 6
+            """;
+        String expectedOutput = """
+            1
+            4
+            0
+            """;
+
+        String actualOutput = TestUtil.executeTest(input, () -> runUnchecked(() -> Main.main(new String[0])));
+        assertEquals(expectedOutput, actualOutput);
+    }
+
+}

--- a/baekjoon/silver/level1/test_11497/Main.java
+++ b/baekjoon/silver/level1/test_11497/Main.java
@@ -1,0 +1,35 @@
+package silver.level1.test_11497;
+
+import java.util.Arrays;
+import java.util.Scanner;
+
+public class Main {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int t = sc.nextInt();
+
+        for (int i = 0; i < t; i++) {
+            int n = sc.nextInt();
+            int[] arr = new int[n];
+            for (int j = 0; j < n; j++) {
+                arr[j] = sc.nextInt();
+            }
+
+            int max = 0;
+            Arrays.sort(arr);
+
+            int[] copyArr = new int[n];
+            int index = 0;
+
+            for (int j = 0; j < n; j += 2) copyArr[index++] = arr[j];
+            index = n - 1;
+            for (int j = 1; j < n; j += 2) copyArr[index--] = arr[j];
+            for (int j = 1; j < n; j++) {
+                max = Math.max(Math.abs(copyArr[j - 1] - copyArr[j]), max);
+            }
+            max = Math.max(Math.abs(copyArr[0] - copyArr[n - 1]), max);
+
+            System.out.println(max);
+        }
+    }
+}


### PR DESCRIPTION
### Summary
- Generates an optimal “pendulum” arrangement of log heights to minimize the maximum adjacent difference (difficulty).
- Sorts logs, arranges them in a zigzag order (even indices ascending, odd indices descending), and calculates the maximum adjacent difference in a circular manner.

### Changes
- Sort input array of log heights
- Fill a new array by placing even-indexed logs first, then odd-indexed logs in reverse order
- Compute maximum adjacent difference across the circular arrangement

### Complexity
- Time: O(N log N) (due to sorting + linear pass to rearrange and compute maximum)
- Space: O(N) for the copy array

### Test
- Verified with Baekjoon 11497 sample input/output